### PR TITLE
feat: #34 provision cognito and rds with terraform

### DIFF
--- a/apps/terraform/.terraform.lock.hcl
+++ b/apps/terraform/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/apps/terraform/cognito/cognito.tf
+++ b/apps/terraform/cognito/cognito.tf
@@ -1,0 +1,26 @@
+resource "aws_cognito_user_pool" "pool" {
+  name = "my-app-user-pool"
+
+  # login with email address
+  username_attributes      = ["email"]
+  auto_verified_attributes = ["email"]
+
+  password_policy {
+    minimum_length = 8
+    require_lowercase = true
+    require_numbers   = true
+    require_symbols   = true
+    require_uppercase = true
+  }
+}
+
+resource "aws_cognito_user_pool_client" "client" {
+  name         = "my-app-client"
+  user_pool_id = aws_cognito_user_pool.pool.id
+
+  explicit_auth_flows = [
+    "ALLOW_USER_PASSWORD_AUTH",
+    "ALLOW_REFRESH_TOKEN_AUTH",
+    "ALLOW_USER_SRP_AUTH"
+  ]
+}

--- a/apps/terraform/main.tf
+++ b/apps/terraform/main.tf
@@ -1,0 +1,10 @@
+# Cognito
+module "auth" {
+  source      = "./cognito"
+}
+
+# RDS
+module "db" {
+  source      = "./rds"
+  rds_password = var.rds_password
+}

--- a/apps/terraform/provider.tf
+++ b/apps/terraform/provider.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "ap-northeast-1"
+}

--- a/apps/terraform/rds/rds.tf
+++ b/apps/terraform/rds/rds.tf
@@ -1,0 +1,26 @@
+# RDS security group
+resource "aws_security_group" "rds_sg" {
+  name = "rds-security-group"
+
+  ingress {
+    from_port   = 5432
+    to_port     = 5432
+    protocol    = "tcp"
+    cidr_blocks = ["116.64.234.139/32"] # dev
+  }
+}
+
+# RDS instance
+resource "aws_db_instance" "postgres" {
+  allocated_storage    = 20
+  engine               = "postgres"
+  engine_version       = "16.10"
+  instance_class       = "db.t3.micro"
+  db_name              = "myappdb"
+  username             = "postgres"
+  password             = var.rds_password
+  parameter_group_name = "default.postgres16"
+  skip_final_snapshot  = false
+  publicly_accessible  = false
+  vpc_security_group_ids = [aws_security_group.rds_sg.id]
+}

--- a/apps/terraform/rds/variables.tf
+++ b/apps/terraform/rds/variables.tf
@@ -1,0 +1,4 @@
+variable "rds_password" {
+  type      = string
+  sensitive = true
+}

--- a/apps/terraform/variables.tf
+++ b/apps/terraform/variables.tf
@@ -1,0 +1,4 @@
+variable "rds_password" {
+  type      = string
+  sensitive = true
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces new Terraform-managed AWS infrastructure (Cognito + RDS), where misconfiguration can impact security, cost, and data durability (e.g., security group ingress and final snapshot behavior). Changes are contained to new `apps/terraform` configs but create real cloud resources when applied.
> 
> **Overview**
> Adds a new `apps/terraform` setup to provision AWS resources via Terraform, including a Cognito user pool + client (email login and password policy) and a Postgres RDS instance.
> 
> Wires these up via `main.tf` modules, pins the AWS provider (`~> 5.0`) with a generated `.terraform.lock.hcl`, sets the AWS region to `ap-northeast-1`, and introduces a sensitive `rds_password` variable passed into the RDS module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa5b2e39dc57e38178450d85e61f475b72ac0896. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->